### PR TITLE
Develop a console script to install and uninstall the plugin

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,0 +1,59 @@
+<?php
+
+Artisan::command('pm4-connector-send-email:install', function () {
+    Artisan::call('vendor:publish',
+        [
+            '--tag' => 'bpm-package-email-connector',
+            '--force' => true,
+        ]
+    );
+    /* In case to add parameters to .env file */
+    $envPath = base_path('.env');
+    if (file_exists($envPath)) {
+        $envContent = file_get_contents($envPath);
+
+        $MAIL_DRIVER =  $this->ask(__("Enter your MAIL DRIVER"), 'smtp');
+        $envContent .= "\nMAIL_DRIVER=$MAIL_DRIVER";
+
+        $MAIL_HOST =  $this->ask(__("Enter your MAIL HOST"), 'smtp.yourmail.com');
+        $envContent .= "\nMAIL_HOST=$MAIL_HOST";
+
+        $MAIL_PORT =  $this->ask(__("Enter your MAIL PORT"), '2525');
+        $envContent .= "\nMAIL_PORT=$MAIL_PORT";
+
+        $MAIL_USERNAME =  $this->ask(__("Enter your MAIL USERNAME"), 'username');
+        $envContent .= "\nMAIL_USERNAME=$MAIL_USERNAME";
+
+        $MAIL_PASSWORD =  $this->secret(__("Enter your MAIL PASSWORD (hidden)"), 'password');
+        $envContent .= "\nMAIL_PASSWORD=$MAIL_PASSWORD";
+
+        file_put_contents($envPath, $envContent);
+    }
+
+    $this->info('Connector send email plugin has been installed');
+})->describe('Installs the send mail connector');
+
+Artisan::command('pm4-connector-send-email:uninstall', function () {
+    /* In case to delete parameters to .env file */
+    $envPath = base_path('.env');
+    if (file_exists($envPath)) {
+        $handle = fopen($envPath, "r");
+        $envContent = "";
+        if ($handle) {
+            while (($line = fgets($handle)) !== false) {
+                if (
+                    strpos($line, "MAIL_DRIVER")    === false &&
+                    strpos($line, "MAIL_HOST")      === false &&
+                    strpos($line, "MAIL_PORT")      === false &&
+                    strpos($line, "MAIL_USERNAME")  === false &&
+                    strpos($line, "MAIL_PASSWORD")  === false
+                ){
+                    $envContent .= $line;
+                }
+            }
+            fclose($handle);
+        }
+        file_put_contents($envPath, $envContent);
+    }
+    $this->info('Connector send email plugin Uninstalled');
+})->describe('Uninstalls Connector send email plugin');

--- a/src/PluginServiceProvider.php
+++ b/src/PluginServiceProvider.php
@@ -20,24 +20,29 @@ class PluginServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // Register a javascript library for the modeler
-        $this->registerModelerScript('js/email-connector.js',
-            'vendor/processmaker/connectors/email');
+        if ($this->app->runningInConsole()) {
+            require(__DIR__ . '/../routes/console.php');
+        } else {
+            // Register a javascript library for the modeler
+            $this->registerModelerScript('js/email-connector.js',
+                'vendor/processmaker/connectors/email');
 
-        $this->publishes([
-            __DIR__ . '/../public' => public_path('vendor/processmaker/connectors/email'),
+            $this->publishes([
+                __DIR__ . '/../public' => public_path('vendor/processmaker/connectors/email'),
             ], 'bpm-package-email-connector');
 
-        $this->loadRoutesFrom(__DIR__ . '/routes.php');
+            $this->loadRoutesFrom(__DIR__ . '/routes.php');
 
-        //Register email templates
-        $this->loadViewsFrom(__DIR__ . '/views', 'email');
+            //Register email templates
+            $this->loadViewsFrom(__DIR__ . '/views', 'email');
 
-        //Register a seeder that will be executed in php artisan db:seed
-        $this->registerSeeder(EmailSendSeeder::class);
+            //Register a seeder that will be executed in php artisan db:seed
+            $this->registerSeeder(EmailSendSeeder::class);
 
-        // Complete the plugin booting
-        $this->completePluginBoot();
+            // Complete the plugin booting
+            $this->completePluginBoot();
+        }
+
     }
 
     /**


### PR DESCRIPTION
This commit provides the way to setup and uninstall the plugin by console. The idea is run this script after install the  plugin with composer.

**The steps to setup would be:**
1. Install plugin with composer
2. Setup the plugin
![screenshot from 2019-01-10 09-42-23](https://user-images.githubusercontent.com/44475741/50972131-2ba2af80-14bc-11e9-9cdd-fbaa3e043ba4.png)
The setup is added
![image](https://user-images.githubusercontent.com/44475741/50972224-6b699700-14bc-11e9-9f34-32e114f9d0fa.png)

**The steps to uninstall would be:**
1. Remove the setup
![image](https://user-images.githubusercontent.com/44475741/50972322-b683aa00-14bc-11e9-90ab-14503aa5adbb.png)
The setup is removed:
![image](https://user-images.githubusercontent.com/44475741/50972360-d1561e80-14bc-11e9-94ff-0e89e953367b.png)

2. Uninstall plugin with composer 

